### PR TITLE
Extending logging to configure autoSendInterval

### DIFF
--- a/src/functions/getConfiguration/domain/config.mock.ts
+++ b/src/functions/getConfiguration/domain/config.mock.ts
@@ -7,5 +7,8 @@ export const config : Config = {
     autoRefreshInterval: 20000,
     numberOfDaysToView: 7,
   },
-  loggingUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/logs',
+  logging: {
+    url: 'https://dev.mes.dev-dvsacloud.uk/v1/logs',
+    autoSendInterval: 60000,
+  },
 };

--- a/src/functions/getConfiguration/domain/config.model.ts
+++ b/src/functions/getConfiguration/domain/config.model.ts
@@ -5,5 +5,8 @@ export interface Config {
     autoRefreshInterval: number,
     numberOfDaysToView: number,
   };
-  loggingUrl: string;
+  logging: {
+    url: string;
+    autoSendInterval: number,
+  };
 }

--- a/src/functions/getConfiguration/domain/scopes.constants.ts
+++ b/src/functions/getConfiguration/domain/scopes.constants.ts
@@ -1,6 +1,6 @@
 enum Scope {
-    DEV = 'dev',
-    PROD = 'prod',
-    STAGING = 'staging',
-    UAT = 'uat',
-  }
+  DEV = 'dev',
+  PROD = 'prod',
+  STAGING = 'staging',
+  UAT = 'uat',
+}


### PR DESCRIPTION
Adding autoSendInterval to logging attribute to be able to configure how often does the mobile app have to send logs to the logs microservice.