### PR TITLE
Mes 1608 add supported devices

### DIFF
--- a/src/functions/getConfiguration/domain/config.mock.ts
+++ b/src/functions/getConfiguration/domain/config.mock.ts
@@ -2,6 +2,7 @@ import { Config } from './config.model';
 
 export const config : Config = {
   googleAnalyticsId: 'UA-129489007-3',
+  approvedDeviceIdentifiers: ['iPad7,4'],
   journal: {
     journalUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/journals/{staffNumber}/personal',
     autoRefreshInterval: 20000,

--- a/src/functions/getConfiguration/domain/config.model.ts
+++ b/src/functions/getConfiguration/domain/config.model.ts
@@ -1,5 +1,6 @@
 export interface Config {
   googleAnalyticsId: string;
+  approvedDeviceIdentifiers: string[],
   journal: {
     journalUrl: string,
     autoRefreshInterval: number,

--- a/src/functions/getConfiguration/domain/config.model.ts
+++ b/src/functions/getConfiguration/domain/config.model.ts
@@ -1,6 +1,6 @@
 export interface Config {
   googleAnalyticsId: string;
-  approvedDeviceIdentifiers: string[],
+  approvedDeviceIdentifiers: string[];
   journal: {
     journalUrl: string,
     autoRefreshInterval: number,


### PR DESCRIPTION
Mes-1608  - Supporting change for Mes 1608.  Adding approvedDeviceIdentifiers to config so that the app can block access to the app if running on anything other than an ipad pro 10.5 inch.

