### PR TITLE
add x86_64 to supported devices for running in simulator

### DIFF
--- a/src/functions/getConfiguration/domain/config.mock.ts
+++ b/src/functions/getConfiguration/domain/config.mock.ts
@@ -2,7 +2,10 @@ import { Config } from './config.model';
 
 export const config : Config = {
   googleAnalyticsId: 'UA-129489007-3',
-  approvedDeviceIdentifiers: ['iPad7,4'],
+  approvedDeviceIdentifiers: [
+    'iPad7,4',
+    'x86_64',
+  ],
   journal: {
     journalUrl: 'https://dev.mes.dev-dvsacloud.uk/v1/journals/{staffNumber}/personal',
     autoRefreshInterval: 20000,


### PR DESCRIPTION
The UI tests (which run on the apple simulator) will currently be blocked due to logic around approved devices. 

Add x86_64 (the model returned by ionic/native device) to the list of supported devices so that UI tests will run.
