### PR TITLE
MES-1756 - Config to Know Which Tests to Start

### DIFF
--- a/src/functions/getConfiguration/domain/config.mock.ts
+++ b/src/functions/getConfiguration/domain/config.mock.ts
@@ -15,6 +15,8 @@ export const config : Config = {
     journalUrl: populateEnvironment('https://{env}.mes.dev-dvsacloud.uk/v1/journals/{staffNumber}/personal'),
     autoRefreshInterval: 20000,
     numberOfDaysToView: 7,
+    allowTests: true,
+    allowedTestCategories: ['B'],
   },
   logs: {
     url: populateEnvironment('https://{env}.mes.dev-dvsacloud.uk/v1/logs'),

--- a/src/functions/getConfiguration/domain/config.model.ts
+++ b/src/functions/getConfiguration/domain/config.model.ts
@@ -5,6 +5,8 @@ export interface Config {
     journalUrl: string,
     autoRefreshInterval: number,
     numberOfDaysToView: number,
+    allowTests: boolean,
+    allowedTestCategories: string[],
   };
   logs: {
     url: string;


### PR DESCRIPTION
Adds the configuration needed to let us know if tests can be started and which categories are supported