### PR TITLE
Mes 2266 - Consume backend api url as env var

### DIFF
--- a/src/functions/getConfiguration/domain/config.mock.ts
+++ b/src/functions/getConfiguration/domain/config.mock.ts
@@ -1,28 +1,33 @@
 import { Config } from './config.model';
 import { environment } from '../framework/environment';
+import { getBaseApiUrl } from '../framework/getBaseApiUrl';
 
-const populateEnvironment = (val: string) => {
-  return val.replace('{env}', environment());
+const generateAnalyticsAccountSuffix = (env: string): string => {
+  return env === Scope.PROD ? '4' : '3';
 };
+
 const generateAllowedTestCategories = (env: string): string[] => {
-  return env === 'dev' ? ['B'] : [];
+  return env === Scope.DEV ? ['B'] : [];
 };
+
+const env = environment();
+const baseApiUrl = getBaseApiUrl();
 
 export const config : Config = {
-  googleAnalyticsId: 'UA-129489007-3',
+  googleAnalyticsId: `UA-129489007-${generateAnalyticsAccountSuffix(env)}`,
   approvedDeviceIdentifiers: [
     'iPad7,4',
     'x86_64',
   ],
   journal: {
-    journalUrl: populateEnvironment('https://{env}.mes.dev-dvsacloud.uk/v1/journals/{staffNumber}/personal'),
+    journalUrl: `${baseApiUrl}/journals/{staffNumber}/personal`,
     autoRefreshInterval: 20000,
     numberOfDaysToView: 7,
     allowTests: true,
-    allowedTestCategories: generateAllowedTestCategories(environment()),
+    allowedTestCategories: generateAllowedTestCategories(env),
   },
   logs: {
-    url: populateEnvironment('https://{env}.mes.dev-dvsacloud.uk/v1/logs'),
+    url: `${baseApiUrl}/logs`,
     autoSendInterval: 60000,
   },
 };

--- a/src/functions/getConfiguration/domain/config.mock.ts
+++ b/src/functions/getConfiguration/domain/config.mock.ts
@@ -1,6 +1,7 @@
 import { Config } from './config.model';
 import { environment } from '../framework/environment';
 import { getBaseApiUrl } from '../framework/getBaseApiUrl';
+import { Scope } from './scopes.constants';
 
 const generateAnalyticsAccountSuffix = (env: string): string => {
   return env === Scope.PROD ? '4' : '3';

--- a/src/functions/getConfiguration/domain/scopes.constants.ts
+++ b/src/functions/getConfiguration/domain/scopes.constants.ts
@@ -1,4 +1,4 @@
-enum Scope {
+export enum Scope {
   DEV = 'dev',
   PROD = 'prod',
   STAGING = 'staging',

--- a/src/functions/getConfiguration/framework/getBaseApiUrl.ts
+++ b/src/functions/getConfiguration/framework/getBaseApiUrl.ts
@@ -1,0 +1,1 @@
+export const getBaseApiUrl = () => process.env.BASE_API_URL || 'https://dev.mes.dev-dvsacloud.uk/v1';

--- a/src/functions/getConfiguration/framework/handler.ts
+++ b/src/functions/getConfiguration/framework/handler.ts
@@ -2,6 +2,7 @@ import { APIGatewayProxyEvent } from 'aws-lambda';
 import createResponse from '../../../common/application/utils/createResponse';
 import Response from '../../../common/application/api/Response';
 import { config } from '../domain/config.mock';
+import { Scope } from '../domain/scopes.constants';
 
 export async function handler(event: APIGatewayProxyEvent): Promise<Response> {
 


### PR DESCRIPTION
Link to story - https://jira.i-env.net/browse/MES-2266

Ensure the configuration service is fit for production by allowing a base api url to be consumed by it when constructing the endpoints for journal and logs.