### PR TITLE
MES-3631 - Enforce Minimum App Version

### DIFF
--- a/src/functions/getConfiguration/framework/__tests__/handler.spec.ts
+++ b/src/functions/getConfiguration/framework/__tests__/handler.spec.ts
@@ -129,5 +129,13 @@ describe('handler', () => {
       expect(resp.statusCode).toBe(500);
       expect(createResponse.default).toHaveBeenCalledWith(errorMessages.MISSING_APP_VERSION_ENV_VARIBLE, 500);
     });
+    it('should return 401 when the app version is below the minimum app version', async () => {
+      process.env.MINIMUM_APP_VERSION = '2.1';
+
+      const resp = await handler(dummyApigwEvent);
+
+      expect(resp.statusCode).toBe(401);
+      expect(createResponse.default).toHaveBeenCalledWith(errorMessages.APP_VERSION_BELOW_MINIMUM, 401);
+    });
   });
 });

--- a/src/functions/getConfiguration/framework/__tests__/validateAppVersion.spec.ts
+++ b/src/functions/getConfiguration/framework/__tests__/validateAppVersion.spec.ts
@@ -1,0 +1,55 @@
+import { isAllowedAppVersion } from '../validateAppVersion';
+
+describe('validateAppVersion', () => {
+
+  describe('isAllowedAppVersion', () => {
+    it('should return true if it is an allowed app version - minor version difference', () => {
+      const result = isAllowedAppVersion('2.1', '2.0');
+      expect(result).toEqual(true);
+    });
+    it('should return true if it is an allowed app version - major version difference', () => {
+      const result = isAllowedAppVersion('2.1', '1.0');
+      expect(result).toEqual(true);
+    });
+    it('should return true if it is an allowed app version - higher minor version then current', () => {
+      const result = isAllowedAppVersion('2.1', '1.8');
+      expect(result).toEqual(true);
+    });
+    it('should return false if the current app version is formatted incorrectly test 1', () => {
+      const result = isAllowedAppVersion('abcdef', '1.0');
+      expect(result).toEqual(false);
+    });
+    it('should return false if the current app version is formatted incorrectly test 2', () => {
+      const result = isAllowedAppVersion('1111.1111.111', '1.0');
+      expect(result).toEqual(false);
+    });
+    it('should return false if the current app version is formatted incorrectly test 3', () => {
+      const result = isAllowedAppVersion('10', '1.0');
+      expect(result).toEqual(false);
+    });
+    it('should return false if the minimum app version is formatted incorrectly test 1', () => {
+      const result = isAllowedAppVersion('1.0', 'abcdef');
+      expect(result).toEqual(false);
+    });
+    it('should return false if the minimum app version is formatted incorrectly test 2', () => {
+      const result = isAllowedAppVersion('1.0', '1111.1111.111');
+      expect(result).toEqual(false);
+    });
+    it('should return false if the minimum app version is formatted incorrectly test 3', () => {
+      const result = isAllowedAppVersion('1.0', '10');
+      expect(result).toEqual(false);
+    });
+    it('should return false if it is not an allowed app version - minor version difference', () => {
+      const result = isAllowedAppVersion('2.0', '2.1');
+      expect(result).toEqual(false);
+    });
+    it('should return false if it is not an allowed app version - major version difference', () => {
+      const result = isAllowedAppVersion('1.0', '2.1');
+      expect(result).toEqual(false);
+    });
+    it('should return false if it is not an allowed app version - higher minor version then current', () => {
+      const result = isAllowedAppVersion('1.8', '2.1');
+      expect(result).toEqual(false);
+    });
+  });
+});

--- a/src/functions/getConfiguration/framework/environment.ts
+++ b/src/functions/getConfiguration/framework/environment.ts
@@ -1,1 +1,3 @@
 export const environment = () => process.env.ENVIRONMENT || 'local';
+
+export const getMinimumAppVersion = () => process.env.MINIMUM_APP_VERSION;

--- a/src/functions/getConfiguration/framework/errors.constants.ts
+++ b/src/functions/getConfiguration/framework/errors.constants.ts
@@ -1,0 +1,11 @@
+export const MISSING_APP_VERSION_ENV_VARIBLE =
+    'Unable to retrive the minimum app version from the environment';
+
+export const NO_SCOPE =
+    'No scope provided';
+
+export const NO_APP_VERSION =
+    'No app version provided';
+
+export const NO_STAFF_NUMBER =
+    'No staff number found in request context';

--- a/src/functions/getConfiguration/framework/errors.constants.ts
+++ b/src/functions/getConfiguration/framework/errors.constants.ts
@@ -9,3 +9,6 @@ export const NO_APP_VERSION =
 
 export const NO_STAFF_NUMBER =
     'No staff number found in request context';
+
+export const APP_VERSION_BELOW_MINIMUM =
+    'Current app version is below the minimum required app version';

--- a/src/functions/getConfiguration/framework/handler.ts
+++ b/src/functions/getConfiguration/framework/handler.ts
@@ -6,25 +6,32 @@ import { Scope } from '../domain/scopes.constants';
 import { RemoteConfig } from '@dvsa/mes-config-schema/remote-config';
 import { buildConfig } from '../domain/config-builder';
 import { ExaminerRole } from '../constants/ExaminerRole';
+import { getMinimumAppVersion } from './environment';
+import * as errorMessages from './errors.constants';
 
 export async function handler(event: APIGatewayProxyEvent): Promise<Response> {
   bootstrapLogging('configuration-service', event);
 
+  const minimumAppVersion = getMinimumAppVersion();
+  if (minimumAppVersion === undefined || minimumAppVersion.trim().length === 0) {
+    error(errorMessages.MISSING_APP_VERSION_ENV_VARIBLE);
+    return createResponse(errorMessages.MISSING_APP_VERSION_ENV_VARIBLE, 500);
+  }
+
   if (!event.pathParameters || !event.pathParameters.scope) {
-    error('No scope provided');
-    return createResponse('No Scope Provided', 400);
+    error(errorMessages.NO_SCOPE);
+    return createResponse(errorMessages.NO_SCOPE, 400);
   }
 
   if (!event.queryStringParameters || !event.queryStringParameters.app_version) {
-    error('No app version provided');
-    return createResponse('No app version provided', 400);
+    error(errorMessages.NO_APP_VERSION);
+    return createResponse(errorMessages.NO_APP_VERSION, 400);
   }
 
   const staffNumber = getStaffNumberFromRequestContext(event.requestContext);
   if (!staffNumber) {
-    const msg = 'No staff number found in request context';
-    error(msg);
-    return createResponse(msg, 401);
+    error(errorMessages.NO_STAFF_NUMBER);
+    return createResponse(errorMessages.NO_STAFF_NUMBER, 401);
   }
 
   const examinerRole = getExaminerRoleFromRequestContext(event.requestContext);

--- a/src/functions/getConfiguration/framework/handler.ts
+++ b/src/functions/getConfiguration/framework/handler.ts
@@ -8,6 +8,7 @@ import { buildConfig } from '../domain/config-builder';
 import { ExaminerRole } from '../constants/ExaminerRole';
 import { getMinimumAppVersion } from './environment';
 import * as errorMessages from './errors.constants';
+import { isAllowedAppVersion } from './validateAppVersion';
 
 export async function handler(event: APIGatewayProxyEvent): Promise<Response> {
   bootstrapLogging('configuration-service', event);
@@ -26,6 +27,11 @@ export async function handler(event: APIGatewayProxyEvent): Promise<Response> {
   if (!event.queryStringParameters || !event.queryStringParameters.app_version) {
     error(errorMessages.NO_APP_VERSION);
     return createResponse(errorMessages.NO_APP_VERSION, 400);
+  }
+
+  if (!isAllowedAppVersion(event.queryStringParameters.app_version, minimumAppVersion)) {
+    error(errorMessages.APP_VERSION_BELOW_MINIMUM);
+    return createResponse(errorMessages.APP_VERSION_BELOW_MINIMUM, 401);
   }
 
   const staffNumber = getStaffNumberFromRequestContext(event.requestContext);

--- a/src/functions/getConfiguration/framework/validateAppVersion.ts
+++ b/src/functions/getConfiguration/framework/validateAppVersion.ts
@@ -1,0 +1,33 @@
+import { error } from 'util';
+
+export const isAllowedAppVersion = (requestAppVersion: string , minimumAppVersion: string): boolean => {
+  if (!isVersionCorrectFormat(requestAppVersion) || !isVersionCorrectFormat(minimumAppVersion)) {
+    return false;
+  }
+
+  return (
+    isHigerMajorVersion(getMajorVersionNumber(requestAppVersion), getMajorVersionNumber(minimumAppVersion)) ||
+    (
+        isSameMajorVersion(getMajorVersionNumber(requestAppVersion), getMajorVersionNumber(minimumAppVersion)) &&
+        isHigherOrEqualMinorVersion(getMinorVersionNumber(requestAppVersion), getMinorVersionNumber(minimumAppVersion))
+    )
+  );
+};
+
+const isVersionCorrectFormat = (appVersion: string): boolean =>
+    new RegExp('^[0-9]+\.[0-9]+$').test(appVersion);
+
+const getMajorVersionNumber = (versionNumber: string): number =>
+    Number.parseInt(versionNumber.split('.')[0], 10);
+
+const getMinorVersionNumber = (versionNumber: string): number =>
+    Number.parseInt(versionNumber.split('.')[1], 10);
+
+const isHigerMajorVersion = (appMajorVersion: number , minimumMajorVersion: number): boolean =>
+    appMajorVersion > minimumMajorVersion;
+
+const isSameMajorVersion = (appMajorVersion: number , minimumMajorVersion: number): boolean =>
+    appMajorVersion === minimumMajorVersion;
+
+const isHigherOrEqualMinorVersion = (appMinorVersion: number , minimumMinorVersion: number): boolean =>
+    appMinorVersion >= minimumMinorVersion;

--- a/src/functions/getConfiguration/framework/validateAppVersion.ts
+++ b/src/functions/getConfiguration/framework/validateAppVersion.ts
@@ -1,5 +1,3 @@
-import { error } from 'util';
-
 export const isAllowedAppVersion = (requestAppVersion: string , minimumAppVersion: string): boolean => {
   if (!isVersionCorrectFormat(requestAppVersion) || !isVersionCorrectFormat(minimumAppVersion)) {
     return false;


### PR DESCRIPTION
**New Stuff**
- Require a app_version query string parameter to be present and return a 400 error if it's not
- Require a MINIMUM_APP_VERSION env variable to be present and return a 500 error if it's not
- Require that the app_version is above the MINIMUM_APP_VERSION or return a 401 error,

**Changes**
- Removed some redundant code which can't be reached when getting a users role, and automatically defaulting that role to DE
- Unit tests for all error scenarios in the handler 
- Extracted error messages into a constants file
