### PR TITLE
Adding iPad Pro 10.5 non-cellular to approved devices list for non-pr…

### DIFF
--- a/src/functions/getConfiguration/domain/config.ts
+++ b/src/functions/getConfiguration/domain/config.ts
@@ -12,7 +12,7 @@ const generateAllowedTestCategories = (env: string): string[] => {
 };
 
 const generateApprovedDeviceIdentifiers = (env: string): string[] => {
-  return productionLikeEnvs.includes(env as Scope) ? ['iPad7,4'] : ['iPad7,4', 'x86_64'];
+  return productionLikeEnvs.includes(env as Scope) ? ['iPad7,4'] : ['iPad7,4', 'x86_64', 'iPad7,3'];
 };
 
 const generateautoRefreshInterval = (env: string): number => {


### PR DESCRIPTION
XCode 11 now builds and runs the simulator as the actual device (iPad Pro 10.5 non-cellular - no option to select cellular which is the actual production device) so added iPad7,3 to the list of approved devices for test.