### PR TITLE
MES-2620 update test sending interval config value to 5min

### DIFF
--- a/src/functions/getConfiguration/domain/config.ts
+++ b/src/functions/getConfiguration/domain/config.ts
@@ -42,7 +42,7 @@ export const config: RemoteConfig = {
   },
   tests: {
     testSubmissionUrl: `${baseApiUrl}/test-results`,
-    autoSendInterval: 900000,
+    autoSendInterval: 300000,
   },
   user: {
     findUserUrl: `${baseApiUrl}/users/{staffNumber}`,


### PR DESCRIPTION
Changed test's autoSendInterval value to 5min (from 15)