### PR TITLE
Cherry pick for 3.0.0 - Adding iPad Air (3rd generation) A2123 (iPad11,4) to the approved devices list

### DIFF
--- a/src/functions/getConfiguration/domain/config.ts
+++ b/src/functions/getConfiguration/domain/config.ts
@@ -12,7 +12,8 @@ const generateAllowedTestCategories = (env: string): string[] => {
 };
 
 const generateApprovedDeviceIdentifiers = (env: string): string[] => {
-  return productionLikeEnvs.includes(env as Scope) ? ['iPad7,4'] : ['iPad7,4', 'x86_64', 'iPad7,3'];
+  return productionLikeEnvs.includes(env as Scope) ? ['iPad7,4', 'iPad11,4']
+   : ['iPad7,4', 'iPad11,4', 'x86_64', 'iPad7,3'];
 };
 
 const generateautoRefreshInterval = (env: string): number => {


### PR DESCRIPTION
Cherry pick of change to release-3.0.0 to add iPad Air to list of approved devices.