### PR TITLE
mes-8278: updated to allow des4 specific single app mode

### DIFF
--- a/spec/configuration-service.spec.ts
+++ b/spec/configuration-service.spec.ts
@@ -1,5 +1,5 @@
 import * as supertest from 'supertest';
-import { startSlsOffline } from './helpers/integration-test-lifecycle';
+import { startSlsOffline, stopSlsOffline } from './helpers/integration-test-lifecycle';
 import { RemoteConfig } from '@dvsa/mes-config-schema/remote-config';
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
@@ -7,28 +7,31 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 const request = supertest('http://localhost:3000');
 
 describe('integration test', () => {
-  beforeAll((done) => {
-    startSlsOffline((err: any) => {
-      if (err) {
-        console.error(err);
-        fail();
-      }
-      done();
+    beforeAll((done) => {
+        startSlsOffline((err: any) => {
+            if (err) {
+                console.error(err);
+                fail();
+            }
+            done();
+        });
     });
-  });
+    afterAll(() => {
+        stopSlsOffline();
+    });
 
-  it('should respond 200 for an item that exists', (done) => {
-    request
-      .get('/configuration/dev')
-      .expect(200)
-      .end((err, res) => {
-        if (err) throw err;
-        const response: RemoteConfig = res.body;
-        expect(response.googleAnalyticsId).toBe('UA-129489007-3');
-        expect(response.journal.journalUrl).toBe(
-          'https://dev.mes.dev-dvsacloud.uk/v1/journals/{staffNumber}/personal',
-        );
-        done();
-      });
-  });
+    it('should respond 200 for an item that exists', (done) => {
+        request
+            .get('/configuration/dev')
+            .expect(200)
+            .end((err, res) => {
+                if (err) throw err;
+                const response: RemoteConfig = res.body;
+                expect(response.googleAnalyticsId).toBe('UA-129489007-3');
+                expect(response.journal.journalUrl).toBe(
+                    'https://dev.mes.dev-dvsacloud.uk/v1/journals/{staffNumber}/personal',
+                );
+                done();
+            });
+    });
 });

--- a/spec/helpers/integration-test-lifecycle.ts
+++ b/spec/helpers/integration-test-lifecycle.ts
@@ -21,3 +21,12 @@ export const startSlsOffline = (done: any) => {
     done(errData);
   });
 };
+
+export const stopSlsOffline = () => {
+  // Usage of negative PID kills the process group
+  const { pid } = slsOfflineProcess;
+  if (typeof pid === 'number') {
+    process.kill(-pid);
+    console.log('Serverless Offline stopped');
+  }
+};

--- a/src/functions/getConfiguration/framework/__tests__/handler.spec.ts
+++ b/src/functions/getConfiguration/framework/__tests__/handler.spec.ts
@@ -15,6 +15,7 @@ describe('handler', () => {
 
   beforeEach(() => {
     process.env.MINIMUM_APP_VERSION = '2.0.0.0';
+    process.env.DES4_MINIMUM_APP_VERSION = '4.0.0.0';
 
     moqConfigBuilder.reset();
 

--- a/src/functions/getConfiguration/framework/environment.ts
+++ b/src/functions/getConfiguration/framework/environment.ts
@@ -2,6 +2,8 @@ export const environment = () => process.env.ENVIRONMENT || 'local';
 
 export const getMinimumAppVersion = () => process.env.MINIMUM_APP_VERSION;
 
+export const getDes4MinimumAppVersion = () => process.env.DES4_MINIMUM_APP_VERSION;
+
 export const getLiveAppVersion = () => process.env.LIVE_APP_VERSION;
 
 export const getDES4LiveCats = () => process.env.DES4_LIVE_CATS;


### PR DESCRIPTION
updated to allow des4 specific single app mode

config environment vars:

![image](https://user-images.githubusercontent.com/48550267/199677995-db5e1a6f-85d5-45ae-bdcb-70f7309f44fe.png)

DES4 (4.7.0.0)

<img width="683" alt="image" src="https://user-images.githubusercontent.com/48550267/199677882-8400b46f-39cd-4433-a4ba-31d28d0ae9dd.png">

DES3 (changed logic so unsupported would fire first)

<img width="680" alt="image" src="https://user-images.githubusercontent.com/48550267/199677769-44585cf3-c994-4708-af2c-87ad2dbb9e39.png">

